### PR TITLE
Allow skipping PVC binding check and update default dockerimage

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ var pvcNewName string
 var pvcNewNamespace string
 
 var force bool
+var skipWaitPVCBind bool
 var Version string
 
 // rootCmd represents the base command when called without any subcommands
@@ -34,6 +35,7 @@ var rootCmd = &cobra.Command{
 		for _, pvc := range args {
 			m := migrator.New(kubeConfig)
 			m.Force = force
+			m.WaitForTempDestPVCBind = skipWaitPVCBind
 
 			// We can only support operating in a single namespace currently
 			// Since cross-namespace PVC mounts are not a thing
@@ -85,6 +87,7 @@ func init() {
 	rootCmd.Flags().StringVar(&pvcNewNamespace, "new-pvc-namespace", "", "Namespace for the new PVCs to be created in. If empty, the namespace from your kubeconfig file will be used.")
 
 	rootCmd.Flags().BoolVar(&force, "force", false, "Ignore warning which would normally halt the tool during validation.")
+	rootCmd.Flags().BoolVar(&skipWaitPVCBind, "skip-pvc-bind-wait", false, "Skip waiting for PVC to be bound.")
 
 	rootCmd.Flags().StringVar(&config.DockerImage, "docker-image", config.DockerImage, "Image to use for moving jobs")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,3 +1,3 @@
 package config
 
-var DockerImage = "korb-mover:latest"
+var DockerImage = "ghcr.io/beryju/korb-mover:latest"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,3 +1,3 @@
 package config
 
-var DockerImage = "beryju.org/korb-mover:latest"
+var DockerImage = "korb-mover:latest"

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -19,6 +19,8 @@ type Migrator struct {
 
 	Force bool
 
+	WaitForTempDestPVCBind bool
+
 	kConfig *rest.Config
 	kClient *kubernetes.Clientset
 
@@ -73,7 +75,7 @@ func (m *Migrator) Run() {
 	destTemplate.Name = m.DestPVCName
 	if len(compatibleStrategies) == 1 {
 		m.log.Debug("Only one compatible strategy, running")
-		err := compatibleStrategies[0].Do(sourcePVC, destTemplate)
+		err := compatibleStrategies[0].Do(sourcePVC, destTemplate, m.WaitForTempDestPVCBind)
 		if err != nil {
 			m.log.WithError(err).Warning("Failed to migrate")
 		}

--- a/pkg/strategies/strategy.go
+++ b/pkg/strategies/strategy.go
@@ -26,7 +26,7 @@ func NewBaseStrategy(config *rest.Config, client *kubernetes.Clientset) BaseStra
 type Strategy interface {
 	CompatibleWithControllers(...interface{}) bool
 	Description() string
-	Do(sourcePVC *v1.PersistentVolumeClaim, destTemplate *v1.PersistentVolumeClaim) error
+	Do(sourcePVC *v1.PersistentVolumeClaim, destTemplate *v1.PersistentVolumeClaim, WaitForTempDestPVCBind bool) error
 }
 
 func StrategyInstances(b BaseStrategy) []Strategy {


### PR DESCRIPTION
When using a StorageClass with WaitForFirstConsumer the PVC will not be bound until the Pod is created. This will add an option to skip the check.

The default set image is not available, fetching it from docker hub worked fine.