### PR TITLE
Add ability to change access modes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ var pvcNewStorageClass string
 var pvcNewSize string
 var pvcNewName string
 var pvcNewNamespace string
+var pvcNewAccessModes []string
 
 var force bool
 var skipWaitPVCBind bool
@@ -53,6 +54,7 @@ var rootCmd = &cobra.Command{
 			m.DestPVCSize = pvcNewSize
 			m.DestPVCStorageClass = pvcNewStorageClass
 			m.DestPVCName = pvcNewName
+			m.DestPVCAccessModes = pvcNewAccessModes
 
 			m.SourcePVCName = pvc
 			m.Run()
@@ -86,6 +88,7 @@ func init() {
 	rootCmd.Flags().StringVar(&pvcNewName, "new-pvc-name", "", "Name for the new PVC. If empty, same name will be reused.")
 	rootCmd.Flags().StringVar(&pvcNewSize, "new-pvc-size", "", "Size for the new PVC. If empty, the size of the source will be used. Accepts formats like used in Kubernetes Manifests (Gi, Ti, ...)")
 	rootCmd.Flags().StringVar(&pvcNewNamespace, "new-pvc-namespace", "", "Namespace for the new PVCs to be created in. If empty, the namespace from your kubeconfig file will be used.")
+	rootCmd.Flags().StringSliceVar(&pvcNewAccessModes, "new-pvc-access-mode", []string{}, "Access mode(s) for the new PVC. If empty, the access mode of the source will be used. Accepts formats like used in Kubernetes Manifests (ReadWriteOnce, ReadWriteMany, ...)")
 
 	rootCmd.Flags().BoolVar(&force, "force", false, "Ignore warning which would normally halt the tool during validation.")
 	rootCmd.Flags().BoolVar(&skipWaitPVCBind, "skip-pvc-bind-wait", false, "Skip waiting for PVC to be bound.")

--- a/pkg/migrator/destination.go
+++ b/pkg/migrator/destination.go
@@ -16,6 +16,18 @@ func (m *Migrator) GetDestPVCSize(fallback resource.Quantity) resource.Quantity 
 	return destSize
 }
 
+func (m *Migrator) GetDestPVCAccessModes(fallback []v1.PersistentVolumeAccessMode) []v1.PersistentVolumeAccessMode {
+	var destAccessModes []v1.PersistentVolumeAccessMode
+	if len(m.DestPVCAccessModes) > 0 {
+		for _, accessMode := range m.DestPVCAccessModes {
+			destAccessModes = append(destAccessModes, v1.PersistentVolumeAccessMode(accessMode))
+		}
+	} else {
+		destAccessModes = fallback
+	}
+	return destAccessModes
+}
+
 func (m *Migrator) GetDestinationPVCTemplate(sourcePVC *v1.PersistentVolumeClaim) *v1.PersistentVolumeClaim {
 	var sc *string
 	if m.DestPVCStorageClass != "" {
@@ -27,7 +39,7 @@ func (m *Migrator) GetDestinationPVCTemplate(sourcePVC *v1.PersistentVolumeClaim
 			Namespace: m.DestNamespace,
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes: sourcePVC.Spec.AccessModes,
+			AccessModes: m.GetDestPVCAccessModes(sourcePVC.Spec.AccessModes),
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
 					v1.ResourceName(v1.ResourceStorage): m.GetDestPVCSize(*sourcePVC.Spec.Resources.Requests.Storage()),

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -17,6 +17,7 @@ type Migrator struct {
 	DestPVCStorageClass string
 	DestPVCSize         string
 	DestPVCName         string
+	DestPVCAccessModes  []string
 
 	Force bool
 


### PR DESCRIPTION
Some storage providers (For example, Longhorn) support both RWX and RWO, and behave differently depending on which is chosen. This PR adds the ability to change the new PVC's access mode.

Edit: I should also mention that I've tested this against a few migrations with no issue!