### PR TITLE
Fix inability to rename resulting tar on export if /tmp is on another filesystem (tmpfs)

### DIFF
--- a/pkg/strategies/export.go
+++ b/pkg/strategies/export.go
@@ -86,7 +86,9 @@ func (c *ExportStrategy) CopyOut(pod v1.Pod, config *rest.Config, name string) (
 		return "", err
 	}
 	finalPath := fmt.Sprintf("%s.tar", name)
-	os.Rename(file.Name(), finalPath)
+	if err = os.Rename(file.Name(), finalPath); err != nil {
+		return "", err
+	}
 	return finalPath, nil
 }
 

--- a/pkg/strategies/export.go
+++ b/pkg/strategies/export.go
@@ -3,7 +3,6 @@ package strategies
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"beryju.org/korb/pkg/mover"
@@ -67,7 +66,7 @@ func (c *ExportStrategy) Do(sourcePVC *v1.PersistentVolumeClaim, destTemplate *v
 }
 
 func (c *ExportStrategy) CopyOut(pod v1.Pod, config *rest.Config, name string) (string, error) {
-	file, err := ioutil.TempFile(os.TempDir(), "korb-mover-")
+	file, err := os.CreateTemp(".", "korb-mover-")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
If the temporary directory is on a different filesystem than the one korb is called from, go's `os.Rename` function is unable to rename the file, because it would need to be moved (copy actual bytes) between filesystems:
```
WARN[0010] failed to copy file   component=strategy error="rename /tmp/korb-mover-3168494533 s3-vol.tar: invalid cross-device link" strategy=export
```
The above error was suppressed by not handling it.

This PR avoids using a potential tmpfs, because of it's possible size restrictions and the requirement to move the resulting file, replaces the deprecated `ioutil.TempFile` function and enabled error handling on renaming.