### PR TITLE
Adds the flag to optionally enable all nodes toleration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ var pvcNewAccessModes []string
 
 var force bool
 var skipWaitPVCBind bool
+var tolerateAllNodes bool
 var Version string
 
 // rootCmd represents the base command when called without any subcommands
@@ -35,7 +36,7 @@ var rootCmd = &cobra.Command{
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		for _, pvc := range args {
-			m := migrator.New(kubeConfig, strategy)
+			m := migrator.New(kubeConfig, strategy, tolerateAllNodes)
 			m.Force = force
 			m.WaitForTempDestPVCBind = skipWaitPVCBind
 
@@ -92,6 +93,7 @@ func init() {
 
 	rootCmd.Flags().BoolVar(&force, "force", false, "Ignore warning which would normally halt the tool during validation.")
 	rootCmd.Flags().BoolVar(&skipWaitPVCBind, "skip-pvc-bind-wait", false, "Skip waiting for PVC to be bound.")
+	rootCmd.Flags().BoolVar(&tolerateAllNodes, "tolerate-any-node", false, "Allow job to tolerating any node node taints.")
 
 	rootCmd.Flags().StringVar(&config.ContainerImage, "container-image", config.ContainerImage, "Image to use for moving jobs")
 	rootCmd.Flags().StringVar(&strategy, "strategy", "", "Strategy to use, by default will try to auto-select")

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -19,9 +19,9 @@ type Migrator struct {
 	DestPVCName         string
 	DestPVCAccessModes  []string
 
-	Force bool
-
+	Force                  bool
 	WaitForTempDestPVCBind bool
+	TolerateAllNodes       bool
 
 	kConfig *rest.Config
 	kClient *kubernetes.Clientset
@@ -30,10 +30,11 @@ type Migrator struct {
 	strategy string
 }
 
-func New(kubeconfigPath string, strategy string) *Migrator {
+func New(kubeconfigPath string, strategy string, tolerateAllNode bool) *Migrator {
 	m := &Migrator{
-		log:      log.WithField("component", "migrator"),
-		strategy: strategy,
+		log:              log.WithField("component", "migrator"),
+		TolerateAllNodes: tolerateAllNode,
+		strategy:         strategy,
 	}
 	if kubeconfigPath != "" {
 		m.log.WithField("kubeconfig", kubeconfigPath).Debug("Created client from kubeconfig")

--- a/pkg/migrator/validate.go
+++ b/pkg/migrator/validate.go
@@ -14,7 +14,7 @@ func (m *Migrator) Validate() (*v1.PersistentVolumeClaim, []strategies.Strategy)
 	if err != nil {
 		m.log.WithError(err).Panic("Failed to get controllers")
 	}
-	baseStrategy := strategies.NewBaseStrategy(m.kConfig, m.kClient)
+	baseStrategy := strategies.NewBaseStrategy(m.kConfig, m.kClient, m.TolerateAllNodes)
 	allStrategies := strategies.StrategyInstances(baseStrategy)
 	compatibleStrategies := make([]strategies.Strategy, 0)
 	ctx := strategies.MigrationContext{

--- a/pkg/strategies/copyTwiceName.go
+++ b/pkg/strategies/copyTwiceName.go
@@ -81,7 +81,7 @@ func (c *CopyTwiceNameStrategy) Do(sourcePVC *v1.PersistentVolumeClaim, destTemp
 	}
 
 	c.log.WithField("stage", 2).Debug("starting mover job")
-	c.tempMover = mover.NewMoverJob(c.kClient, mover.MoverTypeSync)
+	c.tempMover = mover.NewMoverJob(c.kClient, mover.MoverTypeSync, c.tolerateAllNodes)
 	c.tempMover.Namespace = destTemplate.ObjectMeta.Namespace
 	c.tempMover.SourceVolume = sourcePVC
 	c.tempMover.DestVolume = c.TempDestPVC
@@ -110,7 +110,7 @@ func (c *CopyTwiceNameStrategy) Do(sourcePVC *v1.PersistentVolumeClaim, destTemp
 	c.DestPVC = destInst
 
 	c.log.WithField("stage", 5).Debug("starting mover job to final PVC")
-	c.finalMover = mover.NewMoverJob(c.kClient, mover.MoverTypeSync)
+	c.finalMover = mover.NewMoverJob(c.kClient, mover.MoverTypeSync, c.tolerateAllNodes)
 	c.finalMover.Namespace = destTemplate.ObjectMeta.Namespace
 	c.finalMover.SourceVolume = c.TempDestPVC
 	c.finalMover.DestVolume = c.DestPVC

--- a/pkg/strategies/export.go
+++ b/pkg/strategies/export.go
@@ -43,7 +43,7 @@ func (c *ExportStrategy) Do(sourcePVC *v1.PersistentVolumeClaim, destTemplate *v
 	c.log.Warning("This strategy assumes you've stopped all pods accessing this data.")
 
 	c.log.Debug("starting mover job")
-	c.tempMover = mover.NewMoverJob(c.kClient, mover.MoverTypeSleep)
+	c.tempMover = mover.NewMoverJob(c.kClient, mover.MoverTypeSleep, c.tolerateAllNodes)
 	c.tempMover.Namespace = destTemplate.ObjectMeta.Namespace
 	c.tempMover.SourceVolume = sourcePVC
 	c.tempMover.Name = fmt.Sprintf("korb-job-%s", sourcePVC.UID)

--- a/pkg/strategies/import.go
+++ b/pkg/strategies/import.go
@@ -47,7 +47,7 @@ func (c *ImportStrategy) Do(sourcePVC *v1.PersistentVolumeClaim, destTemplate *v
 	c.log.Warning("This strategy assumes you've stopped all pods accessing this data.")
 
 	c.log.Debug("starting mover job")
-	c.tempMover = mover.NewMoverJob(c.kClient, mover.MoverTypeSleep)
+	c.tempMover = mover.NewMoverJob(c.kClient, mover.MoverTypeSleep, c.tolerateAllNodes)
 	c.tempMover.Namespace = destTemplate.ObjectMeta.Namespace
 	c.tempMover.SourceVolume = sourcePVC
 	c.tempMover.Name = fmt.Sprintf("korb-job-%s", sourcePVC.UID)

--- a/pkg/strategies/strategy.go
+++ b/pkg/strategies/strategy.go
@@ -12,14 +12,16 @@ type BaseStrategy struct {
 	kConfig *rest.Config
 	kClient *kubernetes.Clientset
 
-	log *log.Entry
+	log              *log.Entry
+	tolerateAllNodes bool
 }
 
-func NewBaseStrategy(config *rest.Config, client *kubernetes.Clientset) BaseStrategy {
+func NewBaseStrategy(config *rest.Config, client *kubernetes.Clientset, tolerateAllNodes bool) BaseStrategy {
 	return BaseStrategy{
-		kConfig: config,
-		kClient: client,
-		log:     log.WithField("component", "strategy"),
+		kConfig:          config,
+		kClient:          client,
+		tolerateAllNodes: tolerateAllNodes,
+		log:              log.WithField("component", "strategy"),
 	}
 }
 


### PR DESCRIPTION
Adding flag to optionally enabel the wildcard node tolerations. Some cluster configurations may not admit the the pod spec with wildcard node toleration, hence such scenarios could prevent korb tool usage.

Improves the change for #220 