### PR TITLE
Add argument for changing serviceAccountName used in the CronJob

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,8 @@ var pvcNewName string
 var pvcNewNamespace string
 var pvcNewAccessModes []string
 
+var serviceAccountName string
+
 var force bool
 var skipWaitPVCBind bool
 var tolerateAllNodes bool
@@ -57,6 +59,8 @@ var rootCmd = &cobra.Command{
 			m.DestPVCName = pvcNewName
 			m.DestPVCAccessModes = pvcNewAccessModes
 
+			m.ServiceAccountName = serviceAccountName
+
 			m.SourcePVCName = pvc
 			m.Run()
 			if len(args) > 1 {
@@ -90,6 +94,8 @@ func init() {
 	rootCmd.Flags().StringVar(&pvcNewSize, "new-pvc-size", "", "Size for the new PVC. If empty, the size of the source will be used. Accepts formats like used in Kubernetes Manifests (Gi, Ti, ...)")
 	rootCmd.Flags().StringVar(&pvcNewNamespace, "new-pvc-namespace", "", "Namespace for the new PVCs to be created in. If empty, the namespace from your kubeconfig file will be used.")
 	rootCmd.Flags().StringSliceVar(&pvcNewAccessModes, "new-pvc-access-mode", []string{}, "Access mode(s) for the new PVC. If empty, the access mode of the source will be used. Accepts formats like used in Kubernetes Manifests (ReadWriteOnce, ReadWriteMany, ...)")
+
+	rootCmd.Flags().StringVar(&serviceAccountName, "service-account-name", "", "Service Account Name to use for the Job execution. If empty, 'default' used.")
 
 	rootCmd.Flags().BoolVar(&force, "force", false, "Ignore warning which would normally halt the tool during validation.")
 	rootCmd.Flags().BoolVar(&skipWaitPVCBind, "skip-pvc-bind-wait", false, "Skip waiting for PVC to be bound.")

--- a/mover/Containerfile
+++ b/mover/Containerfile
@@ -1,0 +1,8 @@
+FROM registry.redhat.io/ubi9/toolbox:latest
+# For OpenShift use a Red Hat base image.  The toolbox is large but has everything needed for rsync and additional debugging
+
+VOLUME [ "/source", "/dest" ]
+
+COPY ./entrypoint-ocp.sh /bin/entrypoint
+
+ENTRYPOINT [ "/bin/entrypoint" ]

--- a/mover/README.md
+++ b/mover/README.md
@@ -1,0 +1,18 @@
+# Container
+
+Two versions of the container are available depending on your usecase.
+1) Dockerfile - this is the original based on alpine
+2) Containerfile - this targets OpenShift using the Red Hat toolbox image
+
+### Build
+## Dockerfile
+docker build  -t beryju/korb-mover:latest .
+docker tag beryju/korb-mover:latest beryju/korb-mover:v2
+docker tag beryju/korb-mover:v2 ghcr.io/beryju/korb-mover:v2
+docker push ghcr.io/beryju/korb-mover:v2
+
+## Containerfile
+podman build -f Containerfile -t therevoman/korb-mover-ubi9 .
+podman tag therevoman/korb-mover-ubi9:latest therevoman/korb-mover-ubi9:v2
+podman tag therevoman/korb-mover-ubi9:v2 quay.io/therevoman/korb-mover-ubi9:v2
+podman push quay.io/therevoman/korb-mover-ubi9:v2

--- a/mover/entrypoint-ocp.sh
+++ b/mover/entrypoint-ocp.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -xe
+if [[ $1 == "sync" ]]; then
+    # because Red Hat is Security first the built in containers use SELinux and specific privileges.  rsync needed a few more arguments to work
+    ls -alZ /source /dest
+    rsync -axHAX -O --progress /source/ /dest
+elif [[ $1 == "sleep" ]]; then
+    cat
+else
+    echo "No command given. Make sure to use the correct mover image for your korb version."
+    exit 1
+fi

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,3 +1,5 @@
 package config
 
 var ContainerImage = "ghcr.io/beryju/korb-mover:v2"
+
+// var ContainerImageOpenShift = "quay.io/therevoman/korb-mover-ubi9:v2"

--- a/pkg/migrator/destination.go
+++ b/pkg/migrator/destination.go
@@ -41,7 +41,7 @@ func (m *Migrator) GetDestinationPVCTemplate(sourcePVC *v1.PersistentVolumeClaim
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: m.GetDestPVCAccessModes(sourcePVC.Spec.AccessModes),
-			Resources: v1.ResourceRequirements{
+			Resources: v1.VolumeResourceRequirements{
 				Requests: v1.ResourceList{
 					v1.ResourceName(v1.ResourceStorage): m.GetDestPVCSize(*sourcePVC.Spec.Resources.Requests.Storage()),
 				},

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -19,6 +19,8 @@ type Migrator struct {
 	DestPVCName         string
 	DestPVCAccessModes  []string
 
+	ServiceAccountName string
+
 	Force                  bool
 	WaitForTempDestPVCBind bool
 	TolerateAllNodes       bool

--- a/pkg/migrator/validate.go
+++ b/pkg/migrator/validate.go
@@ -14,7 +14,7 @@ func (m *Migrator) Validate() (*v1.PersistentVolumeClaim, []strategies.Strategy)
 	if err != nil {
 		m.log.WithError(err).Panic("Failed to get controllers")
 	}
-	baseStrategy := strategies.NewBaseStrategy(m.kConfig, m.kClient, m.TolerateAllNodes)
+	baseStrategy := strategies.NewBaseStrategy(m.kConfig, m.kClient, m.TolerateAllNodes, m.ServiceAccountName)
 	allStrategies := strategies.StrategyInstances(baseStrategy)
 	compatibleStrategies := make([]strategies.Strategy, 0)
 	ctx := strategies.MigrationContext{
@@ -52,6 +52,12 @@ func (m *Migrator) validateSourcePVC() *v1.PersistentVolumeClaim {
 	if m.DestPVCName == "" {
 		m.log.Debug("No new Name given, using old name")
 		m.DestPVCName = pvc.Name
+	}
+	if m.ServiceAccountName == "" {
+		m.log.Debug("No new Service Account Name given, using 'default'")
+		m.ServiceAccountName = "default"
+	} else {
+		m.log.WithField("service-account-name", m.ServiceAccountName).Debug("Got Service Account Name")
 	}
 	return pvc
 }

--- a/pkg/mover/wait.go
+++ b/pkg/mover/wait.go
@@ -24,7 +24,7 @@ func (m *MoverJob) getPods() []v1.Pod {
 func (m *MoverJob) WaitForRunning() *v1.Pod {
 	// First we wait for all pods to be running
 	var runningPod v1.Pod
-	err := wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
+	err := wait.PollImmediate(15*time.Second, 120*time.Second, func() (bool, error) {
 		pods := m.getPods()
 		if len(pods) != 1 {
 			return false, nil

--- a/pkg/strategies/copyTwiceName.go
+++ b/pkg/strategies/copyTwiceName.go
@@ -85,6 +85,7 @@ func (c *CopyTwiceNameStrategy) Do(sourcePVC *v1.PersistentVolumeClaim, destTemp
 	c.tempMover.Namespace = destTemplate.ObjectMeta.Namespace
 	c.tempMover.SourceVolume = sourcePVC
 	c.tempMover.DestVolume = c.TempDestPVC
+	c.tempMover.ServiceAccountName = c.serviceAccountName
 	c.tempMover.Name = fmt.Sprintf("korb-job-%s", sourcePVC.UID)
 	err = c.tempMover.Start().Wait(c.MoveTimeout)
 	if err != nil {

--- a/pkg/strategies/strategy.go
+++ b/pkg/strategies/strategy.go
@@ -14,14 +14,17 @@ type BaseStrategy struct {
 
 	log              *log.Entry
 	tolerateAllNodes bool
+
+	serviceAccountName string
 }
 
-func NewBaseStrategy(config *rest.Config, client *kubernetes.Clientset, tolerateAllNodes bool) BaseStrategy {
+func NewBaseStrategy(config *rest.Config, client *kubernetes.Clientset, tolerateAllNodes bool, serviceAccountName string) BaseStrategy {
 	return BaseStrategy{
-		kConfig:          config,
-		kClient:          client,
-		tolerateAllNodes: tolerateAllNodes,
-		log:              log.WithField("component", "strategy"),
+		kConfig:            config,
+		kClient:            client,
+		tolerateAllNodes:   tolerateAllNodes,
+		serviceAccountName: serviceAccountName,
+		log:                log.WithField("component", "strategy"),
 	}
 }
 


### PR DESCRIPTION
This set of changes does 2 things.
1) adds an argument for serviceAccountName to run the pod with escalated privileges if needed.
2) provides a 2nd container option for OpenShift platform components that are secured with SELinux 