### PR TITLE
chore: Add v2 major version suffix to module importpath

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"beryju.org/korb/pkg/config"
-	"beryju.org/korb/pkg/migrator"
+	"beryju.org/korb/v2/pkg/config"
+	"beryju.org/korb/v2/pkg/migrator"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module beryju.org/korb
+module beryju.org/korb/v2
 
 go 1.22.0
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "beryju.org/korb/cmd"
+import "beryju.org/korb/v2/cmd"
 
 func main() {
 	cmd.Execute()

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -3,7 +3,7 @@ package migrator
 import (
 	"time"
 
-	"beryju.org/korb/pkg/strategies"
+	"beryju.org/korb/v2/pkg/strategies"
 	log "github.com/sirupsen/logrus"
 
 	"k8s.io/client-go/kubernetes"

--- a/pkg/migrator/validate.go
+++ b/pkg/migrator/validate.go
@@ -3,7 +3,7 @@ package migrator
 import (
 	"context"
 
-	"beryju.org/korb/pkg/strategies"
+	"beryju.org/korb/v2/pkg/strategies"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/mover/mover.go
+++ b/pkg/mover/mover.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"beryju.org/korb/pkg/config"
+	"beryju.org/korb/v2/pkg/config"
 	"github.com/goware/prefixer"
 	log "github.com/sirupsen/logrus"
 

--- a/pkg/strategies/copyTwiceName.go
+++ b/pkg/strategies/copyTwiceName.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"beryju.org/korb/pkg/mover"
+	"beryju.org/korb/v2/pkg/mover"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/strategies/export.go
+++ b/pkg/strategies/export.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	"beryju.org/korb/pkg/mover"
+	"beryju.org/korb/v2/pkg/mover"
 	"github.com/schollz/progressbar/v3"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"

--- a/pkg/strategies/import.go
+++ b/pkg/strategies/import.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	"beryju.org/korb/pkg/mover"
+	"beryju.org/korb/v2/pkg/mover"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 )


### PR DESCRIPTION
This aligns with go module [best practices](https://go.dev/ref/mod#major-version-suffixes) and has the UX benefit of making korb go-installable.